### PR TITLE
Add commonmark-extension package type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "spatie/commonmark-shiki-highlighter",
     "description": "Highlight code blocks with league/commonmark and Shiki",
+    "type": "commonmark-extension",
     "keywords": [
         "spatie",
         "commonmark-shiki-highlighter"


### PR DESCRIPTION
We encourage third-party extensions to use this type to make them more easily findable on Packagist: https://packagist.org/packages/league/commonmark?type=commonmark-extension

(Great work on the extension BTW, I might have to use this myself sometime!)