### PR TITLE
Update to Commonmark v2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `commonmark-shiki-highlighter` will be documented in this file.
 
+## 2.0.0 - 2021-08-04
+
+- upgrade to support commonmark 2.0
+
 ## 1.1.1 - 2021-07-11
 
 - improve deps

--- a/README.md
+++ b/README.md
@@ -47,16 +47,18 @@ yarn add shiki
 Here's how we can create a function that can convert markdown to HTML with all code snippets highlighted. Inside the function will create a new `CommonMarkConverter` that uses the `HighlightCodeExtension` provided by this package.
 
 ```php
-use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\MarkdownConverter;
 use Spatie\CommonMarkShikiHighlighter\HighlightCodeExtension;
 
 function convertToHtml(string $markdown, string $theme): string
 {
-    $environment = Environment::createCommonMarkEnvironment()
+    $environment = (new Environment())
+        ->addExtension(new CommonMarkCoreExtension())
         ->addExtension(new HighlightCodeExtension($theme));
 
-    $commonMarkConverter = new CommonMarkConverter(environment: $environment);
+    $commonMarkConverter = new MarkdownConverter(environment: $environment);
 
     return $commonMarkConverter->convertToHtml($markdown);
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "league/commonmark": "^1.6.5",
+        "league/commonmark": "^2.0",
         "spatie/shiki-php": "^1.1.1",
         "symfony/process": "^5.3"
     },

--- a/src/HighlightCodeExtension.php
+++ b/src/HighlightCodeExtension.php
@@ -2,9 +2,9 @@
 
 namespace Spatie\CommonMarkShikiHighlighter;
 
-use League\CommonMark\Block\Element\FencedCode;
-use League\CommonMark\Block\Element\IndentedCode;
-use League\CommonMark\ConfigurableEnvironmentInterface;
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
+use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
+use League\CommonMark\Extension\CommonMark\Node\Block\IndentedCode;
 use League\CommonMark\Extension\ExtensionInterface;
 use Spatie\CommonMarkShikiHighlighter\Renderers\FencedCodeRenderer;
 use Spatie\CommonMarkShikiHighlighter\Renderers\IndentedCodeRenderer;
@@ -17,14 +17,14 @@ class HighlightCodeExtension implements ExtensionInterface
     ) {
     }
 
-    public function register(ConfigurableEnvironmentInterface $environment)
+    public function register(EnvironmentBuilderInterface $environment): void
     {
         $shiki = new Shiki(defaultTheme: $this->theme);
 
         $codeBlockHighlighter = new ShikiHighlighter($shiki);
 
         $environment
-            ->addBlockRenderer(FencedCode::class, new FencedCodeRenderer($codeBlockHighlighter), 10)
-            ->addBlockRenderer(IndentedCode::class, new IndentedCodeRenderer($codeBlockHighlighter), 10);
+            ->addRenderer(FencedCode::class, new FencedCodeRenderer($codeBlockHighlighter), 10)
+            ->addRenderer(IndentedCode::class, new IndentedCodeRenderer($codeBlockHighlighter), 10);
     }
 }

--- a/src/Renderers/FencedCodeRenderer.php
+++ b/src/Renderers/FencedCodeRenderer.php
@@ -2,15 +2,15 @@
 
 namespace Spatie\CommonMarkShikiHighlighter\Renderers;
 
-use League\CommonMark\Block\Element\AbstractBlock;
-use League\CommonMark\Block\Element\FencedCode;
-use League\CommonMark\Block\Renderer\BlockRendererInterface;
-use League\CommonMark\Block\Renderer\FencedCodeRenderer as BaseFencedCodeRenderer;
-use League\CommonMark\ElementRendererInterface;
+use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
+use League\CommonMark\Extension\CommonMark\Renderer\Block\FencedCodeRenderer as BaseFencedCodeRenderer;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
 use League\CommonMark\Util\Xml;
 use Spatie\CommonMarkShikiHighlighter\ShikiHighlighter;
 
-class FencedCodeRenderer implements BlockRendererInterface
+class FencedCodeRenderer implements NodeRendererInterface
 {
     protected ShikiHighlighter $highlighter;
 
@@ -24,16 +24,15 @@ class FencedCodeRenderer implements BlockRendererInterface
     }
 
     public function render(
-        AbstractBlock $block,
-        ElementRendererInterface $htmlRenderer,
-        $inTightList = false
+        Node $node,
+        ChildNodeRendererInterface $childRenderer
     ): string {
-        $element = $this->baseRenderer->render($block, $htmlRenderer, $inTightList);
+        $element = $this->baseRenderer->render($node, $childRenderer);
 
         $element->setContents(
             $this->highlighter->highlight(
                 $element->getContents(),
-                $this->getSpecifiedLanguage($block)
+                $this->getSpecifiedLanguage($node)
             )
         );
 

--- a/src/Renderers/IndentedCodeRenderer.php
+++ b/src/Renderers/IndentedCodeRenderer.php
@@ -2,13 +2,13 @@
 
 namespace Spatie\CommonMarkShikiHighlighter\Renderers;
 
-use League\CommonMark\Block\Element\AbstractBlock;
-use League\CommonMark\Block\Renderer\BlockRendererInterface;
-use League\CommonMark\Block\Renderer\IndentedCodeRenderer as BaseIndentedCodeRenderer;
-use League\CommonMark\ElementRendererInterface;
+use League\CommonMark\Extension\CommonMark\Renderer\Block\IndentedCodeRenderer as BaseIndentedCodeRenderer;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
 use Spatie\CommonMarkShikiHighlighter\ShikiHighlighter;
 
-class IndentedCodeRenderer implements BlockRendererInterface
+class IndentedCodeRenderer implements NodeRendererInterface
 {
     protected ShikiHighlighter $highlighter;
 
@@ -22,11 +22,10 @@ class IndentedCodeRenderer implements BlockRendererInterface
     }
 
     public function render(
-        AbstractBlock $block,
-        ElementRendererInterface $htmlRenderer,
-        $inTightList = false
+        Node $node,
+        ChildNodeRendererInterface $childRenderer
     ): string {
-        $element = $this->baseRenderer->render($block, $htmlRenderer, $inTightList);
+        $element = $this->baseRenderer->render($node, $childRenderer);
 
         $element->setContents(
             $this->highlighter->highlight($element->getContents())

--- a/tests/HighlightCodeExtensionTest.php
+++ b/tests/HighlightCodeExtensionTest.php
@@ -2,8 +2,9 @@
 
 namespace Spatie\CommonMarkShikiHighlighter\Tests;
 
-use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\MarkdownConverter;
 use PHPUnit\Framework\TestCase;
 use Spatie\CommonMarkShikiHighlighter\HighlightCodeExtension;
 use Spatie\Snapshots\MatchesSnapshots;
@@ -72,10 +73,11 @@ class HighlightCodeExtensionTest extends TestCase
 
     protected function convertToHtml(string $markdown): string
     {
-        $environment = Environment::createCommonMarkEnvironment()
+        $environment = (new Environment())
+            ->addExtension(new CommonMarkCoreExtension())
             ->addExtension(new HighlightCodeExtension('nord'));
 
-        $commonMarkConverter = new CommonMarkConverter(environment: $environment);
+        $commonMarkConverter = new MarkdownConverter(environment: $environment);
 
         return $commonMarkConverter->convertToHtml($markdown);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,47 +2,47 @@
 # yarn lockfile v1
 
 
-json5@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+"json5@^2.2.0":
+  "integrity" "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA=="
+  "resolved" "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz"
+  "version" "2.2.0"
   dependencies:
-    minimist "^1.2.5"
+    "minimist" "^1.2.5"
 
-lru-cache@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
-  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+"lru-cache@^5.1.1":
+  "integrity" "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="
+  "resolved" "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz"
+  "version" "5.1.1"
   dependencies:
-    yallist "^3.0.2"
+    "yallist" "^3.0.2"
 
-minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+"minimist@^1.2.5":
+  "integrity" "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+  "resolved" "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz"
+  "version" "1.2.5"
 
-onigasm@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/onigasm/-/onigasm-2.2.5.tgz#cc4d2a79a0fa0b64caec1f4c7ea367585a676892"
-  integrity sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==
+"onigasm@^2.2.5":
+  "integrity" "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA=="
+  "resolved" "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz"
+  "version" "2.2.5"
   dependencies:
-    lru-cache "^5.1.1"
+    "lru-cache" "^5.1.1"
 
-shiki@^0.9.5:
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.9.5.tgz#c8da81a05fbfd1810729c6873901a729a72ec541"
-  integrity sha512-XFn+rl3wIowDjzdr5DlHoHgQphXefgUTs2bNp/bZu4WF9gTrTLnKwio3f28VjiFG6Jpip7yQn/p4mMj6OrjrtQ==
+"shiki@^0.9.5":
+  "integrity" "sha512-XFn+rl3wIowDjzdr5DlHoHgQphXefgUTs2bNp/bZu4WF9gTrTLnKwio3f28VjiFG6Jpip7yQn/p4mMj6OrjrtQ=="
+  "resolved" "https://registry.npmjs.org/shiki/-/shiki-0.9.5.tgz"
+  "version" "0.9.5"
   dependencies:
-    json5 "^2.2.0"
-    onigasm "^2.2.5"
-    vscode-textmate "5.2.0"
+    "json5" "^2.2.0"
+    "onigasm" "^2.2.5"
+    "vscode-textmate" "5.2.0"
 
-vscode-textmate@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
-  integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
+"vscode-textmate@5.2.0":
+  "integrity" "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
+  "resolved" "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz"
+  "version" "5.2.0"
 
-yallist@^3.0.2:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
-  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+"yallist@^3.0.2":
+  "integrity" "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+  "resolved" "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz"
+  "version" "3.1.1"


### PR DESCRIPTION
# Description
This pull request makes commonmark-shiki-highlighter compatible with league/commonmark v2. By upgrading to v2, support for v1 is dropped. **This is a breaking change**, and therefor I marked the release in the changelog as 2.0.

## Notes
I need to push on my branch again to trigger Github Actions. Locally tests don't pass, but I think this is due to Windows \r\n instead of expected \n.
**EDIT:** It seems like the tests pass on Github 😄 

## Changes: 
- Added a changelog entry. This is now a new major version.
- Updated composer.json to be in line with the new commonmark requirements
- Updated the tests to use the new namespaces
- Updated the readme to show an updated code sample

## Closing
Would you like me to not commit the yarn.lock file?
Let me know if there is anything else you need.