### PR TITLE
feat: allow creating extension with instantiated `Shiki` object

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,21 @@ function convertToHtml(string $markdown, string $theme): string
 {
     $environment = (new Environment())
         ->addExtension(new CommonMarkCoreExtension())
-        ->addExtension(new HighlightCodeExtension($theme));
+        ->addExtension(new HighlightCodeExtension(theme: $theme));
 
     $markdownConverter = new MarkdownConverter(environment: $environment);
 
     return $markdownConverter->convertToHtml($markdown);
 }
+```
+
+Alternatively, you can inject an already instantiated `Shiki` instance into the `HighlightCodeExtension`:
+
+```php
+use Spatie\ShikiPhp\Shiki;
+use Spatie\CommonMarkShikiHighlighter\HighlightCodeExtension;
+
+$environment->addExtension(new HighlightCodeExtension(shiki: new Shiki()));
 ```
 
 ## Using themes

--- a/src/HighlightCodeExtension.php
+++ b/src/HighlightCodeExtension.php
@@ -12,19 +12,17 @@ use Spatie\ShikiPhp\Shiki;
 
 class HighlightCodeExtension implements ExtensionInterface
 {
-    public function __construct(
-        protected string $theme
-    ) {
+    protected ShikiHighlighter $shikiHighlighter;
+
+    public function __construct(string $theme = 'nord', Shiki $shiki = null)
+    {
+        $this->shikiHighlighter = new ShikiHighlighter($shiki ?? new Shiki($theme));
     }
 
     public function register(EnvironmentBuilderInterface $environment): void
     {
-        $shiki = new Shiki(defaultTheme: $this->theme);
-
-        $codeBlockHighlighter = new ShikiHighlighter($shiki);
-
         $environment
-            ->addRenderer(FencedCode::class, new FencedCodeRenderer($codeBlockHighlighter), 10)
-            ->addRenderer(IndentedCode::class, new IndentedCodeRenderer($codeBlockHighlighter), 10);
+            ->addRenderer(FencedCode::class, new FencedCodeRenderer($this->shikiHighlighter), 10)
+            ->addRenderer(IndentedCode::class, new IndentedCodeRenderer($this->shikiHighlighter), 10);
     }
 }

--- a/tests/HighlightCodeExtensionTest.php
+++ b/tests/HighlightCodeExtensionTest.php
@@ -7,6 +7,7 @@ use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\MarkdownConverter;
 use PHPUnit\Framework\TestCase;
 use Spatie\CommonMarkShikiHighlighter\HighlightCodeExtension;
+use Spatie\ShikiPhp\Shiki;
 use Spatie\Snapshots\MatchesSnapshots;
 
 class HighlightCodeExtensionTest extends TestCase
@@ -69,6 +70,27 @@ class HighlightCodeExtensionTest extends TestCase
         $highlightedCode = $this->convertToHtml($markdown);
 
         $this->assertMatchesSnapshot($highlightedCode);
+    }
+
+    /** @test */
+    public function can_create_with_a_shiki_instance()
+    {
+        $markdown = <<<MD
+        Here is a piece of indented PHP code
+
+            <?php echo "Hello World"; ?>
+
+        MD;
+
+        $environment = (new Environment())
+            ->addExtension(new CommonMarkCoreExtension())
+            ->addExtension(new HighlightCodeExtension(shiki: new Shiki()));
+
+        $commonMarkConverter = new MarkdownConverter(environment: $environment);
+
+        $highlightedCode = $commonMarkConverter->convertToHtml($markdown);
+
+        $this->assertMatchesSnapshot((string) $highlightedCode);
     }
 
     protected function convertToHtml(string $markdown): string

--- a/tests/__snapshots__/HighlightCodeExtensionTest__can_create_with_a_shiki_instance__1.txt
+++ b/tests/__snapshots__/HighlightCodeExtensionTest__can_create_with_a_shiki_instance__1.txt
@@ -1,0 +1,3 @@
+<p>Here is a piece of indented PHP code</p>
+<pre class="shiki" style="background-color: #2e3440ff"><code><span class="line"><span style="color: #81A1C1">&lt;?</span><span style="color: #D8DEE9FF">php </span><span style="color: #81A1C1">echo</span><span style="color: #D8DEE9FF"> </span><span style="color: #ECEFF4">&quot;</span><span style="color: #A3BE8C">Hello World</span><span style="color: #ECEFF4">&quot;</span><span style="color: #81A1C1">;</span><span style="color: #D8DEE9FF"> </span><span style="color: #81A1C1">?&gt;</span></span>
+<span class="line"></span></code></pre>


### PR DESCRIPTION
Small refactor to allow injecting an already instantiated `Shiki` object. My use-case is I have a `CachedShiki` implementation to cache the calls to shiki.js.

I understand removing the `protected string $theme` is a small BC break. Feels trivial to me but I totally understand if it isn't acceptable.