### PR TITLE
Fix: Make parameter nullable to fix PHP 8.4 deprecation notice

### DIFF
--- a/src/HighlightCodeExtension.php
+++ b/src/HighlightCodeExtension.php
@@ -17,7 +17,7 @@ class HighlightCodeExtension implements ExtensionInterface
     /**
      * @param string|array<string, string> $theme Can be a single theme or an array with a light and a dark theme.
      */
-    public function __construct(mixed $theme = 'nord', Shiki $shiki = null, bool $throw = false)
+    public function __construct(mixed $theme = 'nord', ?Shiki $shiki = null, bool $throw = false)
     {
         $this->shikiHighlighter = new ShikiHighlighter($shiki ?? new Shiki($theme), $throw);
     }


### PR DESCRIPTION
I'm doing a quick pass to check if I can upgrade my blog to PHP 8.4 and bumped into a deprecation notice with this package.

PHP 8.4 [deprecates implicitly nullable types](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated), and because of this the constructor of `HighlightCodeExtension` causes a deprecation notice to be displayed when an instance is initialized when using PHP 8.4.

Since it seems the package supports PHP 8.0 and up and the suggested solution for PHP 7.1 and up seems to be to simply make the parameter nullable, that's what I've done, figured I might as well make a PR too.

(I did a quick check and all tests pass, but I didn't run PHP-CS-Fixer since it does not support PHP 8.4 yet.)